### PR TITLE
Add Gemini API support as alternative to OpenAI in edamize()

### DIFF
--- a/R/edamize.R
+++ b/R/edamize.R
@@ -62,13 +62,17 @@ edamize = function(
    file.copy(system.file("curbioc", package="biocEDAM"), tempdir(), recursive=TRUE)
    curbioc = reticulate::import_from_path("curbioc.curbioc", path=tempdir(), convert=FALSE)
    oai = reticulate::import("openai", convert=FALSE)
+   gemini = reticulate::import("google.generativeai", convert = FALSE)
    json = reticulate::import("json", convert=FALSE)
    
-   OPENAI_API_KEY = os$getenv('OPENAI_API_KEY')
-   MODEL="gpt-4o"
-   client = oai$OpenAI(api_key=OPENAI_API_KEY)
+   # OPENAI_API_KEY = os$getenv('OPENAI_API_KEY')
+   # MODEL="gpt-4o"
+   # client = oai$OpenAI(api_key=OPENAI_API_KEY)
    
-   
+   gemini_key = os$getenv("GEMINI_API_KEY")
+   gemini$config$configure(api_key = gemini_key)
+   client = gemini$GenerativeModel("gemini-2.0-flash")  
+
    #
    ## Retrieve schemas
    #


### PR DESCRIPTION
Enable Gemini Integration for edamize()
We’re adding support for Gemini via ellmer, selectable with provider="gemini" or "openai"(default). 

Here are the key references:

📘 [chat_google_gemini() documentation](https://ellmer.tidyverse.org/reference/chat_google_gemini.html)
🔑 [How to get and use a Gemini API key](https://ai.google.dev/gemini-api/docs/api-key)